### PR TITLE
Optimize citation loading

### DIFF
--- a/backend/open_webui/retrieval/reference_store.py
+++ b/backend/open_webui/retrieval/reference_store.py
@@ -4,6 +4,8 @@ from typing import Dict
 # Simple in-memory store for document snippets.
 # Keyed by unique UUID string, value is document text.
 DOCUMENT_REFERENCES: Dict[str, str] = {}
+# Store full citation/source lists referenced by id
+CITATION_REFERENCES: Dict[str, list] = {}
 
 def store_document(content: str) -> str:
     """Store a document snippet and return its reference id."""
@@ -14,3 +16,13 @@ def store_document(content: str) -> str:
 def get_document(ref_id: str) -> str | None:
     """Retrieve a document snippet by reference id."""
     return DOCUMENT_REFERENCES.get(ref_id)
+
+def store_sources(sources: list) -> str:
+    """Store a list of sources/citations and return its reference id."""
+    ref_id = str(uuid.uuid4())
+    CITATION_REFERENCES[ref_id] = sources
+    return ref_id
+
+def get_sources(ref_id: str) -> list | None:
+    """Retrieve stored sources/citations by reference id."""
+    return CITATION_REFERENCES.get(ref_id)

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -208,6 +208,15 @@ async def get_document_by_reference(ref_id: str, user=Depends(get_verified_user)
     return {"content": doc}
 
 
+@router.get("/sources/{ref_id}")
+async def get_sources_by_reference(ref_id: str, user=Depends(get_verified_user)):
+    """Return stored citation sources by reference id."""
+    sources = reference_store.get_sources(ref_id)
+    if sources is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sources reference not found")
+    return {"sources": sources}
+
+
 class CollectionNameForm(BaseModel):
     collection_name: Optional[str] = None
 

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -57,6 +57,7 @@ from open_webui.models.functions import Functions
 from open_webui.models.models import Models
 
 from open_webui.retrieval.utils import get_sources_from_files
+from open_webui.retrieval import reference_store
 
 
 from open_webui.utils.chat import generate_chat_completion
@@ -984,7 +985,9 @@ async def process_chat_payload(request, form_data, user, metadata, model):
     ]
 
     if len(sources) > 0:
-        events.append({"sources": sources})
+        # Store sources server side and send only reference id to reduce payload
+        sources_ref = reference_store.store_sources(sources)
+        events.append({"sources_ref": sources_ref})
 
     if model_knowledge:
         await event_emitter(

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -581,3 +581,30 @@ export const getDocumentByReference = async (id: string) => {
 
         return res;
 };
+
+export const getSourcesByReference = async (id: string) => {
+        let error = null;
+
+        const res = await fetch(`${RETRIEVAL_API_BASE_URL}/sources/${id}`, {
+                method: 'GET',
+                headers: {
+                        Accept: 'application/json'
+                },
+                credentials: 'include'
+        })
+                .then(async (res) => {
+                        if (!res.ok) throw await res.json();
+                        return res.json();
+                })
+                .catch((err) => {
+                        error = err.detail;
+                        console.error(err);
+                        return null;
+                });
+
+        if (error) {
+                throw error;
+        }
+
+        return res;
+};

--- a/src/lib/apis/streaming/index.ts
+++ b/src/lib/apis/streaming/index.ts
@@ -2,14 +2,15 @@ import { EventSourceParserStream } from 'eventsource-parser/stream';
 import type { ParsedEvent } from 'eventsource-parser';
 
 type TextStreamUpdate = {
-	done: boolean;
-	value: string;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	sources?: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	selectedModelId?: any;
-	error?: any;
-	usage?: ResponseUsage;
+        done: boolean;
+        value: string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        sources?: any;
+        sourcesRef?: string;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        selectedModelId?: any;
+        error?: any;
+        usage?: ResponseUsage;
 };
 
 type ResponseUsage = {
@@ -67,10 +68,15 @@ async function* openAIStreamToIterator(
 				break;
 			}
 
-			if (parsedData.sources) {
-				yield { done: false, value: '', sources: parsedData.sources };
-				continue;
-			}
+                        if (parsedData.sources) {
+                                yield { done: false, value: '', sources: parsedData.sources };
+                                continue;
+                        }
+
+                        if (parsedData.sources_ref) {
+                                yield { done: false, value: '', sourcesRef: parsedData.sources_ref };
+                                continue;
+                        }
 
 			if (parsedData.selected_model_id) {
 				yield { done: false, value: '', selectedModelId: parsedData.selected_model_id };
@@ -107,10 +113,14 @@ async function* streamLargeDeltasAsRandomChunks(
 			yield textStreamUpdate;
 			continue;
 		}
-		if (textStreamUpdate.sources) {
-			yield textStreamUpdate;
-			continue;
-		}
+                if (textStreamUpdate.sources) {
+                        yield textStreamUpdate;
+                        continue;
+                }
+                if (textStreamUpdate.sourcesRef) {
+                        yield textStreamUpdate;
+                        continue;
+                }
 		if (textStreamUpdate.selectedModelId) {
 			yield textStreamUpdate;
 			continue;

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -333,11 +333,11 @@
 						message.code_executions = message.code_executions;
 					} else {
 						// Regular source.
-						if (message?.sources) {
-							message.sources.push(data);
-						} else {
-							message.sources = [data];
-						}
+                                                if (message?.sources) {
+                                                        message.sources.push(data);
+                                                } else {
+                                                        message.sources = [data];
+                                                }
 					}
 				} else if (type === 'notification') {
 					const toastType = data?.type ?? 'info';
@@ -1181,16 +1181,20 @@
 		}
 	};
 
-	const chatCompletionEventHandler = async (data, message, chatId) => {
-		const { id, done, choices, content, sources, selected_model_id, error, usage } = data;
+       const chatCompletionEventHandler = async (data, message, chatId) => {
+               const { id, done, choices, content, sources, sourcesRef, selected_model_id, error, usage } = data;
 
 		if (error) {
 			await handleOpenAIError(error, message);
 		}
 
-		if (sources) {
-			message.sources = sources;
-		}
+               if (sources) {
+                       message.sources = sources;
+               }
+
+               if (sourcesRef) {
+                       message.sourcesRef = sourcesRef;
+               }
 
 		if (choices) {
 			if (choices[0]?.message?.content) {

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -48,9 +48,10 @@
 	import ContentRenderer from './ContentRenderer.svelte';
 	import { KokoroWorker } from '$lib/workers/KokoroWorker';
 	import FileItem from '$lib/components/common/FileItem.svelte';
-	import FollowUps from './ResponseMessage/FollowUps.svelte';
-	import { fade } from 'svelte/transition';
-	import { flyAndScale } from '$lib/utils/transitions';
+import FollowUps from './ResponseMessage/FollowUps.svelte';
+import { fade } from 'svelte/transition';
+import { flyAndScale } from '$lib/utils/transitions';
+import { getSourcesByReference } from '$lib/apis/retrieval';
 
 	interface MessageType {
 		id: string;
@@ -75,7 +76,8 @@
 		};
 		done: boolean;
 		error?: boolean | { content: string };
-		sources?: string[];
+                sources?: string[];
+                sourcesRef?: string;
 		code_executions?: {
 			uuid: string;
 			name: string;
@@ -105,9 +107,9 @@
 
 	export let chatId = '';
 	export let history;
-	export let messageId;
+export let messageId;
 
-	let message: MessageType = JSON.parse(JSON.stringify(history.messages[messageId]));
+let message: MessageType = JSON.parse(JSON.stringify(history.messages[messageId]));
 	$: if (history.messages) {
 		if (JSON.stringify(message) !== JSON.stringify(history.messages[messageId])) {
 			message = JSON.parse(JSON.stringify(history.messages[messageId]));
@@ -123,7 +125,21 @@
 	export let updateChat: Function;
 	export let editMessage: Function;
 	export let saveMessage: Function;
-	export let rateMessage: Function;
+export let rateMessage: Function;
+
+let loadingSources = false;
+
+async function loadSources() {
+        if (message.sources || !message.sourcesRef) return;
+        loadingSources = true;
+        try {
+                const res = await getSourcesByReference(message.sourcesRef);
+                message.sources = res.sources;
+        } catch (e) {
+                console.error(e);
+        }
+        loadingSources = false;
+}
 	export let actionMessage: Function;
 	export let deleteMessage: Function;
 
@@ -848,9 +864,17 @@
 									<Error content={message?.error?.content ?? message.content} />
 								{/if}
 
-								{#if (message?.sources || message?.citations) && (model?.info?.meta?.capabilities?.citations ?? true)}
-									<Citations id={message?.id} sources={message?.sources ?? message?.citations} />
-								{/if}
+                                                                {#if (message?.sources || message?.citations) && (model?.info?.meta?.capabilities?.citations ?? true)}
+                                                                        <Citations id={message?.id} sources={message.sources ?? message.citations} />
+                                                                {:else if message?.sourcesRef && (model?.info?.meta?.capabilities?.citations ?? true)}
+                                                                        <button class="text-xs underline" on:click={loadSources} disabled={loadingSources}>
+                                                                                {#if loadingSources}
+                                                                                        Loading references...
+                                                                                {:else}
+                                                                                        Show references
+                                                                                {/if}
+                                                                        </button>
+                                                                {/if}
 
 								{#if message.code_executions}
 									<CodeExecutions codeExecutions={message.code_executions} />


### PR DESCRIPTION
## Summary
- store citations in memory and return a reference ID
- expose `/sources/{id}` in the retrieval API
- send `sources_ref` over streaming events
- lazy load citations in the chat UI on demand

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*

------
https://chatgpt.com/codex/tasks/task_e_684a6c6fbaa48324b68dd6a4fa07ec5e