### PR TITLE
Fix temporary chat prompt persistence

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2110,16 +2110,18 @@
 									transparentBackground={$settings?.backgroundImageUrl ?? false}
 									{stopResponse}
 									{createMessagePair}
-									onChange={(input) => {
-										if (input.prompt !== null) {
-											localStorage.setItem(
-												`chat-input${$chatId ? `-${$chatId}` : ''}`,
-												JSON.stringify(input)
-											);
-										} else {
-											localStorage.removeItem(`chat-input${$chatId ? `-${$chatId}` : ''}`);
-										}
-									}}
+                                                                        onChange={(input) => {
+                                                                               if (!$temporaryChatEnabled) {
+                                                                                       if (input.prompt !== null) {
+                                                                                               localStorage.setItem(
+                                                                                                       `chat-input${$chatId ? `-${$chatId}` : ''}`,
+                                                                                                       JSON.stringify(input)
+                                                                                               );
+                                                                                       } else {
+                                                                                               localStorage.removeItem(`chat-input${$chatId ? `-${$chatId}` : ''}`);
+                                                                                       }
+                                                                               }
+                                                                        }}
 									on:upload={async (e) => {
 										const { type, data } = e.detail;
 

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -204,13 +204,15 @@
 					{stopResponse}
 					{createMessagePair}
 					placeholder={$i18n.t('How can I help you today?')}
-					onChange={(input) => {
-						if (input.prompt !== null) {
-							localStorage.setItem(`chat-input`, JSON.stringify(input));
-						} else {
-							localStorage.removeItem(`chat-input`);
-						}
-					}}
+                                        onChange={(input) => {
+                                                if (!$temporaryChatEnabled) {
+                                                        if (input.prompt !== null) {
+                                                                localStorage.setItem(`chat-input`, JSON.stringify(input));
+                                                        } else {
+                                                                localStorage.removeItem(`chat-input`);
+                                                        }
+                                                }
+                                        }}
 					on:upload={(e) => {
 						dispatch('upload', e.detail);
 					}}


### PR DESCRIPTION
## Summary
- avoid saving prompts from temporary sessions in `localStorage`
- update `Chat.svelte` and `Placeholder.svelte` to guard writes with `$temporaryChatEnabled`

## Testing
- `npm run test:frontend` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: boto3, docker)*

------
https://chatgpt.com/codex/tasks/task_e_684be848033c8324ba9734ffe051f630